### PR TITLE
kafka flink docker 환경 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,68 @@ services:
     depends_on:
       - web
 
+  zookeeper:
+    image: zookeeper:3.9
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    volumes:
+      - zookeeper_data:/data
+      - zookeeper_datalog:/datalog
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.1
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    depends_on:
+      - zookeeper
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+
+  flink-jobmanager:
+    build:
+      context: ./flink
+      dockerfile: Dockerfile
+    container_name: flink_jobmanager
+    command: jobmanager
+    ports:
+      - "8081:8081"
+    depends_on:
+      - kafka
+    volumes:
+      - flink_checkpoints:/opt/flink/checkpoints
+      - flink_savepoints:/opt/flink/savepoints
+      - flink_logs:/opt/flink/log
+
+  flink-taskmanager:
+    build:
+      context: ./flink
+      dockerfile: Dockerfile
+    container_name: flink_taskmanager
+    command: taskmanager
+    depends_on:
+      - flink-jobmanager
+    volumes:
+      - flink_checkpoints:/opt/flink/checkpoints
+      - flink_savepoints:/opt/flink/savepoints
+      - flink_logs:/opt/flink/log
+
 # 데이터 볼륨 정의
 volumes:
   postgres_data:
+  zookeeper_data:
+  zookeeper_datalog:
+  kafka_data:
+  flink_checkpoints:
+  flink_savepoints:
+  flink_logs:

--- a/flink/Dockerfile
+++ b/flink/Dockerfile
@@ -1,0 +1,9 @@
+# HomePick/flink/Dockerfile
+# Flink base image for local JobManager/TaskManager.
+FROM flink:1.17.2-scala_2.12-java11
+
+WORKDIR /opt/flink
+
+# 기본 설정 복사. 필요 시 compose 환경변수로 덮어쓰기 가능.
+COPY conf/flink-conf.yaml /opt/flink/conf/flink-conf.yaml
+COPY conf/log4j-console.properties /opt/flink/conf/log4j-console.properties

--- a/flink/conf/flink-conf.yaml
+++ b/flink/conf/flink-conf.yaml
@@ -1,0 +1,11 @@
+# HomePick/flink/conf/flink-conf.yaml
+# 로컬 개발용 기본 설정. compose에서 jobmanager/taskmanager로 분리 시 주소를 맞춰주세요.
+jobmanager.rpc.address: jobmanager
+jobmanager.rpc.port: 6123
+jobmanager.heap.size: 1024m
+taskmanager.heap.size: 1024m
+taskmanager.numberOfTaskSlots: 2
+parallelism.default: 2
+state.backend: filesystem
+state.checkpoints.dir: file:///opt/flink/checkpoints
+state.savepoints.dir: file:///opt/flink/savepoints

--- a/flink/conf/log4j-console.properties
+++ b/flink/conf/log4j-console.properties
@@ -1,0 +1,9 @@
+# HomePick/flink/conf/log4j-console.properties
+# 콘솔 로깅 설정 (Flink 기본 템플릿 기반)
+log4j.rootLogger=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+log4j.logger.org.apache.kafka=INFO
+log4j.logger.org.apache.zookeeper=INFO

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,0 +1,7 @@
+# HomePick/kafka/Dockerfile
+# Kafka base image for local deployments. Compose will supply env vars.
+# Bitnami base image (use a broadly available tag to avoid pull failures).
+FROM bitnami/kafka:latest
+
+# Optional custom server configs. Extend or override as needed before build.
+COPY config/server.properties /opt/bitnami/kafka/config/server.properties

--- a/kafka/config/server.properties
+++ b/kafka/config/server.properties
@@ -1,0 +1,22 @@
+# HomePick/kafka/config/server.properties
+# 기본 Kafka 브로커 설정 (필요에 따라 compose/env에서 덮어쓰기)
+broker.id=1
+listeners=PLAINTEXT://:9092
+advertised.listeners=PLAINTEXT://kafka:9092
+num.network.threads=3
+num.io.threads=8
+socket.send.buffer.bytes=102400
+socket.receive.buffer.bytes=102400
+socket.request.max.bytes=104857600
+log.dirs=/bitnami/kafka/data
+num.partitions=3
+num.recovery.threads.per.data.dir=1
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+log.retention.hours=168
+zookeeper.connect=zookeeper:2181
+zookeeper.connection.timeout.ms=18000
+
+# 개발 환경 전용: 자동 토픽 생성 허용
+auto.create.topics.enable=true


### PR DESCRIPTION
## 📌 개요
Kafka/Flink 로컬 실행 환경을 추가하고 docker-compose에 합쳤습니다.

## ✨ 주요 변경 사항
- Kafka/Zookeeper/Flink(JobManager/TaskManager) 서비스를 compose에 추가
- Kafka/Flink용 Dockerfile과 기본 설정 파일 추가
- Kafka 이미지를 Confluent로 바꿔 빌드/풀 실패 해결

## 🔍 관련 이슈
- close #9 

## 🙏 To Reviewers
- `docker-compose.yml`의 `version` 경고는 무시해도 되며, 필요하면 줄만 지우세요.
- Flink/Kafka 설정은 로컬 기본값입니다. 운영용이면 포트·리소스·보안 설정을 따로 검토해주세요.

## 🔗 문서
- [Confluent Kafka 이미지](https://hub.docker.com/r/confluentinc/cp-kafka)
- [Flink 설정 문서](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/deployment/config/)

## 🧪 테스트 방법
1. `docker compose up --build`
2. `docker compose ps`로 모두 Up 확인
3. Kafka 테스트:
   - `docker compose exec kafka kafka-topics --list --bootstrap-server kafka:9092`
   - 프로듀서/컨슈머로 메시지 송수신 테스트
4. 포트 확인: 프론트 `http://localhost:8080`, 백엔드 `http://localhost:8000`, Flink UI `http://localhost:8081`

## 📸 스크린샷/동작 확인
<img width="1164" height="160" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/715f0b2f-4516-4986-8f66-0aa36f61278d" />


## ✅ 체크리스트
- [x] docker compose로 컨테이너 기동 확인
- [x] 테스트 작성/통과